### PR TITLE
Skip generating individual sub-pages of modular pages

### DIFF
--- a/blackhole.php
+++ b/blackhole.php
@@ -24,6 +24,13 @@ class BlackholePlugin extends Plugin {
 
       // get all routes from grav
       $routes = $this->grav['pages']->routes();
+      
+      // Skip individual modular pages that aren't meant to be viewed alone.
+      foreach ($routes as $path => $dir) {
+        if (strpos($path,'/_') !== FALSE) {
+          unset($routes[$path]);
+        }
+      }
 
       if (!empty($_GET['output_path'])) {
         $this->content = $output_path;


### PR DESCRIPTION
Modular pages in Grav are meant to be viewed as a whole, and each sub-page of them doesn't make sense to be viewed on its own. This PR removes those sub-pages (i.e., parts of modular pages) from the ?pages=all listing that Blackhole uses.

The method for doing this is to just look for `/_` in the Grav path for each page, since modular page parts start with underscores, and unset any that exist. That's a little hacky, so better ways would be great, but it worked fine for me.